### PR TITLE
chore: bump Catch2 to v3.15.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Files excluded from trailing-whitespace hook (ncdump outputs trailing spaces):
 
 - CLI11 v2.6.2
 - spdlog v1.17.0
-- Catch2 v3.15.0
+- Catch2 v3.15.1
 
 ## Test Data
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.15.0
+  GIT_TAG        v3.15.1
 )
 
 FetchContent_MakeAvailable(cli11 spdlog Catch2)


### PR DESCRIPTION
Resolves the dependency-update check in #12.

## What
Bumps the Catch2 test framework `GIT_TAG` from `v3.15.0` to `v3.15.1` (and updates the reference in `CLAUDE.md`).

## Why
v3.15.1 is a patch release with two bug fixes:
- OOB read when scanning for the start of a broken UTF-8 sequence during linebreaking (catchorg/Catch2#3096)
- ODR violation from `TEMPLATE_LIST_TEST_CASE_METHOD` and `CATCH_TEMPLATE_PRODUCT_TEST_CASE` (catchorg/Catch2#3161)

Catch2 is a **test-only** dependency pulled via `FetchContent`; it is not linked into the shipped `dbd2netCDF`/`dbd2csv` binaries, so this carries no risk for users.

## Verification
- Configure confirmed it fetched the `v3.15.1` tag
- Clean Release build
- `ctest` — **31/31 passing** locally

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)