### PR TITLE
build: update Catch2 to v3.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.15.1
+  GIT_TAG        v3.15.2
 )
 
 FetchContent_MakeAvailable(cli11 spdlog Catch2)


### PR DESCRIPTION
Resolves #14. Updated Catch2 dependency in CMakeLists.txt to v3.15.2.