### PR TITLE
Update Catch2 to v3.15.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.15.2
+  GIT_TAG        v3.15.3
 )
 
 FetchContent_MakeAvailable(cli11 spdlog Catch2)


### PR DESCRIPTION
Closes #16. This updates the Catch2 dependency in CMakeLists.txt to version v3.15.3.